### PR TITLE
出品機能制限

### DIFF
--- a/app/controllers/productions_controller.rb
+++ b/app/controllers/productions_controller.rb
@@ -1,4 +1,5 @@
 class ProductionsController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
 
 
 


### PR DESCRIPTION
#what
 ログインユーザーしか出品できないようにした。
#why
 不特定の出品を防ぐため